### PR TITLE
관리자 메인페이지,강의 List 페이지 수정, 강의 No순으로 정렬 추가

### DIFF
--- a/src/main/java/com/kosta/springbootproject/adminservice/ClassesService.java
+++ b/src/main/java/com/kosta/springbootproject/adminservice/ClassesService.java
@@ -49,7 +49,7 @@ public class ClassesService {
 	}
 	
 	public List<Classes> selectAll(){
-		List<Classes> classesList = (List<Classes>)classesRepo.findAll();
+		List<Classes> classesList = (List<Classes>)classesRepo.findAllByOrderByClassNoDesc();
 		return classesList;
 	}
 

--- a/src/main/java/com/kosta/springbootproject/persistence/ClassesRepository.java
+++ b/src/main/java/com/kosta/springbootproject/persistence/ClassesRepository.java
@@ -21,6 +21,9 @@ public interface ClassesRepository extends CrudRepository<Classes, Long>, Queryd
 	//강의를 종강일 순으로 정렬해서 조회
 	public List<Classes> findAllByOrderByClassCloseDateAsc();
 	
+	//강의를 넘버순으로 정렬해서 조회
+	public List<Classes> findAllByOrderByClassNoDesc();
+	
 	
 	public default Predicate makePredicateSubHallClasses(String keyword, Long subNo, Long lecHallNo) {
 		BooleanBuilder builder = new BooleanBuilder();

--- a/src/main/resources/templates/admin/adminMain.html
+++ b/src/main/resources/templates/admin/adminMain.html
@@ -421,6 +421,7 @@ $(function() {
 		                     <tr>
 		                        <th>개강예정일</th>
 		                        <th>강의명</th>
+		                        <th>강사명</th>
 		                        <th>상태</th>
 		                     </tr>
 		                  </thead>
@@ -428,6 +429,7 @@ $(function() {
 		                     <tr th:each="classes:${openExpectedList}">
 		                        <td th:text="${classes.classOpenDate}">개강예정일</td>
 		                        <td th:text="${classes.lecture.course.courseName}">강의명</td>
+		                        <td th:text="${classes.teacher.teacherName}">강사명</td>
 		                        <td th:if="${#strings.toString(classes.classState)}=='APPLY'" th:text="수강신청">상태</td>
 		                        <td th:if="${#strings.toString(classes.classState)}=='END'" th:text="마감">상태</td>
 		                        <td th:if="${#strings.toString(classes.classState)}=='CLOSE'" th:text="종강">상태</td>
@@ -446,6 +448,7 @@ $(function() {
 		                     <tr>
 		                        <th>종강예정일</th>
 		                        <th>강의명</th>
+		                        <th>강사명</th>
 		                        <th>상태</th>
 		                     </tr>
 		                  </thead>
@@ -453,6 +456,7 @@ $(function() {
 		                     <tr th:each="classes:${closeExpectedList}">
 		                        <td th:text="${classes.classCloseDate}">종강예정일</td>
 		                        <td th:text="${classes.lecture.course.courseName}">강의명</td>
+		                        <td th:text="${classes.teacher.teacherName}">강사명</td>
 		                        <td th:if="${#strings.toString(classes.classState)}=='APPLY'" th:text="수강신청">상태</td>
 		                        <td th:if="${#strings.toString(classes.classState)}=='END'" th:text="마감">상태</td>
 		                        <td th:if="${#strings.toString(classes.classState)}=='CLOSE'" th:text="종강">상태</td>

--- a/src/main/resources/templates/admin/classeslist.html
+++ b/src/main/resources/templates/admin/classeslist.html
@@ -24,9 +24,10 @@
 		</div>
 	<!-- 엑셀 다운용 코드 끝-->
 
-		<table class="table table-striped table-bordered table-hover">
+		<table>
 		<thead>
 			<tr>
+				<th>강의번호</th>
 				<th>주제명</th>
 				<th>강의명</th>
 				<th>강사명</th>
@@ -38,6 +39,7 @@
 		</thead>
 		<tbody>
 			<tr th:each="classes:${classeslist}">
+				<td th:text="${classes.classNo}">강의번호</td>
 				<td th:text="${classes.lecture.course.subject.subName}">주제명</td>
 				<td><a th:href="@{'/admin/classesDetail/'+${classes.classNo}}" th:text="${classes.lecture.course.courseName}"></a></td>
 				<td th:text="${classes.teacher.teacherName}">강사명</td>


### PR DESCRIPTION
1.관리자 메인페이지
-개강임박강의, 종강임박강의 부분 강사명 추가
-adminMain.html

2.강의 List 페이지
-정렬을 위한 강의번호 추가
-classeslist.html

3. 강의 No순으로 정렬 추가
-ClassesService.java
-ClassesRepository.java